### PR TITLE
[hotfix] only apply SQLAlchemy limit where needed

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -515,7 +515,8 @@ class SqlaTable(Model, BaseDatasource):
                 direction = asc if ascending else desc
                 qry = qry.order_by(direction(col))
 
-        qry = qry.limit(row_limit)
+        if row_limit:
+            qry = qry.limit(row_limit)
 
         if is_timeseries and \
                 timeseries_limit and groupby and not time_groupby_inline:


### PR DESCRIPTION
Observed issue in dev environment where SQL queries were emitted with
`LIMIT 0`. This fix addresses it.